### PR TITLE
EXPLORE-10: Application unable to start

### DIFF
--- a/src/main/java/com/exploresg/authservice/ExploresgAuthServiceApplication.java
+++ b/src/main/java/com/exploresg/authservice/ExploresgAuthServiceApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = (SecurityAutoConfiguration.class))
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 public class ExploresgAuthServiceApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
This pull request includes a minor syntax update to the `ExploresgAuthServiceApplication.java` file. The change updates the annotation to use curly braces for the `exclude` parameter, which is the preferred syntax when excluding one or more classes.Issue for app unable to start resolved

The error you're seeing:

java: annotation value must be a class literal
is caused by the incorrect use of parentheses in the @SpringBootApplication annotation. In Java annotations, the exclude attribute expects a class literal array, not a single-element tuple.

### ✅ Correct syntax:
`@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})`

### ❌ Incorrect syntax:
`@SpringBootApplication(exclude = (SecurityAutoConfiguration.class)) // This is treated as a tuple, not an array`

### Why this matters:
Java annotations require array syntax ({}) even for a single class. The parentheses () are interpreted differently and lead to a compilation error.