### PR TITLE
EXPLORE-24: Unit Test Improvements and CI File Change

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -1,4 +1,4 @@
-name: "CI Backend - Build, Test & Security Scan"
+name: "CI Auth-Service - Build, Test & Security Scan"
 
 on:
   push:

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
 		<jacoco.skip>false</jacoco.skip>
 	</properties>
 	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<!-- control JaCoCo instrumentation; set to false to enable coverage in CI -->
+		<jacoco.skip>false</jacoco.skip>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -117,7 +119,12 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.10</version>
+				<!-- bumped to a newer JaCoCo release to support newer JDK class versions -->
+				<version>0.8.13</version>
+				<configuration>
+					<!-- use property to skip agent when necessary -->
+					<skip>${jacoco.skip}</skip>
+				</configuration>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>

--- a/src/main/java/com/exploresg/authservice/service/JwtService.java
+++ b/src/main/java/com/exploresg/authservice/service/JwtService.java
@@ -91,9 +91,6 @@ public class JwtService {
     private Claims extractAllClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(getSignInKey())
-                // allow small clock skew (1 second) to avoid failing on millisecond timing
-                // races in tests
-                .setAllowedClockSkewSeconds(1)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/src/main/java/com/exploresg/authservice/service/JwtService.java
+++ b/src/main/java/com/exploresg/authservice/service/JwtService.java
@@ -91,6 +91,9 @@ public class JwtService {
     private Claims extractAllClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(getSignInKey())
+                // allow small clock skew (1 second) to avoid failing on millisecond timing
+                // races in tests
+                .setAllowedClockSkewSeconds(1)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();


### PR DESCRIPTION
This pull request introduces several improvements to the CI configuration, code coverage reporting, and JWT token parsing. The main changes include updating the CI workflow name for clarity, enhancing JaCoCo integration for test coverage, and improving JWT parsing reliability in tests.

**CI and build process improvements:**

* Renamed the GitHub Actions workflow from "CI Backend - Build, Test & Security Scan" to "CI Auth-Service - Build, Test & Security Scan" for better clarity and alignment with the service being tested.

**Code coverage enhancements:**

* Added the `jacoco.skip` property (defaulting to `false`) in `pom.xml` to control JaCoCo code coverage instrumentation, making it easier to enable or disable coverage as needed.
* Upgraded the `jacoco-maven-plugin` from version `0.8.10` to `0.8.13` to support newer JDK class versions and configured it to respect the `jacoco.skip` property for flexible coverage control.

**Testing and reliability improvements:**

* Added a 1-second allowed clock skew in JWT parsing to prevent test failures due to millisecond-level timing races, improving test reliability.