### PR TITLE
EXPLORE-48-Integration-Tests: Integration Tests Added

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -100,7 +100,7 @@ jobs:
                   LOGGING_LEVEL_ROOT: ${{ github.event.inputs.log_level }}
               run: |
                   echo "🌟 Running Hello World Integration Tests..."
-                  ./mvnw test -Dtest="HelloWorldIntegrationTest" -B -Dspring.profiles.active=integration-test
+                  ./mvnw verify -P integration-tests -B
                   echo "✅ Hello World integration tests completed!"
 
             - name: 🗄️ Run Database Integration Tests
@@ -114,7 +114,7 @@ jobs:
                   SPRING_DATASOURCE_PASSWORD: testpass
               run: |
                   echo "🗃️ Running Database Integration Tests..."
-                  ./mvnw test -Dtest="**/AuthServiceDatabaseIntegrationTest" -B -Dspring.profiles.active=integration-test
+                  ./mvnw verify -P integration-tests -B
                   echo "✅ Database integration tests completed!"
 
             - name: 🌐 Run API Endpoint Tests


### PR DESCRIPTION
This pull request updates the way integration tests are executed in the GitHub Actions workflow by standardizing the Maven commands used for both the Hello World and Database integration tests. Instead of specifying individual test classes, the workflow now uses the Maven `verify` phase with the `integration-tests` profile, which provides a more consistent and maintainable approach.

**CI workflow improvements:**

* Updated the Hello World integration test step to use `./mvnw verify -P integration-tests -B` instead of running a specific test class, ensuring all relevant integration tests are executed according to the Maven profile.
* Updated the Database integration test step to use `./mvnw verify -P integration-tests -B` for the same reasons, replacing the previous approach of targeting a specific test class pattern.