### PR TITLE
EXPLORE-51: Updated Docker Push file

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,16 +8,19 @@ on:
         branches:
             - main
             - "release/**"
+            # - "feature/**"
     workflow_dispatch:
         inputs:
             image_tag:
-                description: "Docker image tag (default: latest)"
-                required: false
-                default: "latest"
+                description: "Docker image version tag (e.g., v1.0.0)"
+                required: true
+                default: "v1.0.0"
+
 jobs:
     docker-publish:
         name: 🐳 Docker Build & Publish
         runs-on: ubuntu-latest
+
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -31,6 +34,10 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Get Git SHA
+              id: git_sha
+              run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
             - name: Build and push Docker image
               uses: docker/build-push-action@v5
               with:
@@ -39,4 +46,7 @@ jobs:
                   push: true
                   tags: |
                       ${{ secrets.DOCKERHUB_USERNAME }}/exploresg-auth-service:latest
-                      ${{ secrets.DOCKERHUB_USERNAME }}/exploresg-auth-service:${{ github.sha }}
+                      ${{ secrets.DOCKERHUB_USERNAME }}/exploresg-auth-service:sha-${{ steps.git_sha.outputs.sha_short }}
+                      ${{ secrets.DOCKERHUB_USERNAME }}/exploresg-auth-service:${{ github.event.inputs.image_tag || 'latest' }}
+                  cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/exploresg-auth-service:latest
+                  cache-to: type=inline


### PR DESCRIPTION
This pull request updates the Docker publish GitHub Actions workflow to improve image tagging, versioning, and caching. The main changes include requiring an explicit image version tag for manual dispatches, adding a short Git SHA tag, and optimizing Docker layer caching.

**Workflow improvements:**

* The workflow now requires an explicit Docker image version tag input (`image_tag`) when manually triggered, making versioning more consistent and intentional.
* The workflow adds a new tag to each Docker image build using the short Git SHA, improving traceability of image versions. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R37-R40) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L42-R52)
* Docker build caching is enhanced by specifying `cache-from` and `cache-to` options, which speeds up subsequent builds.

**Tagging and triggering changes:**

* The default value and description for the `image_tag` input have been updated to encourage semantic versioning (e.g., `v1.0.0`), and the input is now required.
* The workflow includes a commented-out pattern for triggering on `feature/**` branches, suggesting future flexibility for branch-based builds.